### PR TITLE
iOS穿山甲sdk缺少依赖库

### DIFF
--- a/AppDocs/usemodule/iOSModuleConfig/uniad.md
+++ b/AppDocs/usemodule/iOSModuleConfig/uniad.md
@@ -37,7 +37,7 @@
 
 |依赖库|系统库|依赖资源|
 |:--|:--|:--|
-|libUniAD.a、libSDWebImage.a、libUniAd-Csj.a、BUAdSDK.framework、BUFoundation.framework|StoreKit.framework、MobileCoreServices.framework、WebKit.framework、MediaPlayer.framework、CoreMedia.framework、CoreLocation.framework、AVFoundation.framework、CoreTelephony.framework、SystemConfiguration.framework、AdSupport.framework、CoreMotion.framework、libresolv.9.tbd、libc++.tbd、libz.tbd、libsqlite3.tbd|BUAdSDK.bundle|
+|libUniAD.a、libSDWebImage.a、libUniAd-Csj.a、BUAdSDK.framework、BUFoundation.framework|StoreKit.framework、MobileCoreServices.framework、WebKit.framework、MediaPlayer.framework、CoreMedia.framework、CoreLocation.framework、AVFoundation.framework、CoreTelephony.framework、SystemConfiguration.framework、AdSupport.framework、CoreMotion.framework、libresolv.9.tbd、libc++.tbd、libz.tbd、libsqlite3.tbd、libbz2.1.0.tbd|BUAdSDK.bundle|
 
 ## 腾讯广点通
 ### 添加依赖资源及文件


### PR DESCRIPTION
集成穿山甲SDK需添加依赖库libbz2.1.0.tbd。否则会报'_BZ2_bzRead'等字段Undefined symbols错误。